### PR TITLE
BugFix: Fix file upload path error when Root Directory is not defaults

### DIFF
--- a/helpers/netSuiteRestClient.js
+++ b/helpers/netSuiteRestClient.js
@@ -11,10 +11,14 @@ const BAD_VERSION_ERROR = {
 
 function getRelativePath(absFilePath) {
     var rootDirectory = vscode.workspace.getConfiguration('netSuiteUpload').rootDirectory;
+    var joinPath = absFilePath.slice(vscode.workspace.rootPath.length)
     if (rootDirectory) {
-        return path.join(rootDirectory, absFilePath.slice(vscode.workspace.rootPath.length));
+        if (joinPath) {
+            joinPath = joinPath.split('/').slice(2).join('/')
+        }
+        return path.join(rootDirectory, joinPath);
     } else {
-        return path.join('SuiteScripts', absFilePath.slice(vscode.workspace.rootPath.length));
+        return path.join('SuiteScripts', joinPath);
     }
 }
 


### PR DESCRIPTION
When I configure the subfolder path, the uploaded files will appear in the subfolder path I set, and a folder will be created in the subfolder corresponding to the subfolder. So I processed the path to make sure the final path is correct.